### PR TITLE
Increase SDP fragment buffer size

### DIFF
--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -376,7 +376,7 @@ static gboolean whip_send_candidates(gpointer user_data) {
 	if(candidates == NULL || g_async_queue_length(candidates) == 0)
 		return TRUE;
 	/* Prepare the fragment to send (credentials + fake mline + candidate) */
-	char fragment[1024];
+	char fragment[4096];
 	g_snprintf(fragment, sizeof(fragment),
 		"a=ice-ufrag:%s\r\n"
 		"a=ice-pwd:%s\r\n"


### PR DESCRIPTION
1024 was not enough on a host with both IPv4 and IPv6 addresses.
Increase to 4096.  We should probably be sending multiple fragments
when we overflow.
