### PR TITLE
Added option to disable trickle, and send candidates in the SDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Application Options:
   -t, --token           Authentication Bearer token to use (optional)
   -A, --audio           GStreamer pipeline to use for audio (optional, required if audio-only)
   -V, --video           GStreamer pipeline to use for video (optional, required if video-only)
+  -n, --no-trickle      Don't trickle candidates, but put them in the SDP offer (default: false)
   -f, --follow-link     Use the Link headers returned by the WHIP server to automatically configure STUN/TURN servers to use (default: false)
   -S, --stun-server     STUN server to use, if any (stun://hostname:port)
   -T, --turn-server     TURN server to use, if any; can be called multiple times (turn(s)://username:password@host:port?transport=[udp,tcp])


### PR DESCRIPTION
As the subject says, this PR adds a "no-trickle" mode: when enabled, the WHIP client will not trickle candidates via PATCH (default behaviour), but will wait for the gathering to complete to then add all candidates to the SDP offer instead. This shouldn't be needed even for servers that don't support trickle, as `prflx` candidates should still manage to get things working, but it's good to have the option anyway.