### PR TITLE
docker: update to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye AS builder
+FROM debian:bookworm AS builder
 
 RUN apt-get update --allow-releaseinfo-change && \
     apt-get install -y --no-install-recommends \
@@ -16,7 +16,7 @@ RUN apt-get update --allow-releaseinfo-change && \
         gstreamer1.0-plugins-good \
         libglib2.0-dev \
         libgstreamer-plugins-bad1.0-dev \
-        libsoup2.4-dev \
+        libsoup-3.0-dev \
         libjson-glib-dev \
         libgstreamer1.0-dev \
         libgstreamer-plugins-base1.0-dev \


### PR DESCRIPTION
bullseye does not expose `libsoup-3.0` development package while bookwork does:
https://packages.debian.org/search?keywords=libsoup-3.0-dev&searchon=names&suite=stable&section=all

In the Makefile there is an explicit dependency to 3.0:
https://github.com/meetecho/simple-whip-client/blob/f5eeb51575a1022b6043afc25ff5f55a4e957222/Makefile#L3

Also updating the library version dependency for the Dockerfile